### PR TITLE
Remove Xten from function name

### DIFF
--- a/flowcell_parser/classes.py
+++ b/flowcell_parser/classes.py
@@ -9,14 +9,14 @@ import glob
 from collections import OrderedDict
 from bs4 import BeautifulSoup #html parser
 
-class XTenParser(object):
-    """Parses an xten run files. It generates data for statusdb
+class RunParser(object):
+    """Parses an Illumina run folder. It generates data for statusdb
     notable attributes :
     
-    :XTenRunInfoParser runinfo: see XTenRunInfo
-    :XTenRunParametersParser runparameters: see XTenRunParametersParser
-    :XTenSampleSheetParser samplesheet: see XTenSampleSheetParser
-    :XTenLaneBarcodeParser lanebarcodes: see XTenLaneBarcodeParser
+    :RunInfoParser runinfo: see RunInfo
+    :RunParametersParser runparameters: see RunParametersParser
+    :SampleSheetParser samplesheet: see SampleSheetParser
+    :LaneBarcodeParser lanebarcodes: see LaneBarcodeParser
     """
     def __init__(self, path):
         if os.path.exists(path):
@@ -25,45 +25,47 @@ class XTenParser(object):
             self.parse()
             self.create_db_obj()
         else:
-            raise os.error("XTen flowcell cannot be found at {0}".format(path))
+            raise os.error(" flowcell cannot be found at {0}".format(path))
 
-    def parse(self):
+
+
+    def parse(self, demultiplexingDir='Demultiplexing'):
         """Tries to parse as many files as possible from a run folder"""
         fc_name=os.path.basename(os.path.abspath(self.path)).split('_')[-1][1:]
         rinfo_path=os.path.join(self.path, 'RunInfo.xml')
         rpar_path=os.path.join(self.path, 'runParameters.xml')
         ss_path=os.path.join(self.path, 'SampleSheet.csv')
-        lb_path=os.path.join(self.path, 'Demultiplexing', 'Reports', 'html', fc_name, 'all', 'all', 'all', 'laneBarcode.html')
-        ln_path=os.path.join(self.path, 'Demultiplexing', 'Reports', 'html', fc_name, 'all', 'all', 'all', 'lane.html')
-        demux_path=os.path.join(self.path, 'Demultiplexing')
+        lb_path=os.path.join(self.path, demultiplexingDir, 'Reports', 'html', fc_name, 'all', 'all', 'all', 'laneBarcode.html')
+        ln_path=os.path.join(self.path, demultiplexingDir, 'Reports', 'html', fc_name, 'all', 'all', 'all', 'lane.html')
+        demux_path=os.path.join(self.path, demultiplexingDir)
 
         try:
-            self.runinfo=XTenRunInfoParser(rinfo_path)
+            self.runinfo=RunInfoParser(rinfo_path)
         except OSError as e:
             self.log.info(str(e))
             self.runinfo=None
         try:
-            self.runparameters=XTenRunParametersParser(rpar_path)
+            self.runparameters=RunParametersParser(rpar_path)
         except OSError as e:
             self.log.info(str(e))
             self.runParameters=None
         try:
-            self.samplesheet=XTenSampleSheetParser(ss_path)
+            self.samplesheet=SampleSheetParser(ss_path)
         except OSError as e:
             self.log.info(str(e))
             self.samplesheet=None
         try:
-            self.lanebarcodes=XTenLaneBarcodeParser(lb_path)
+            self.lanebarcodes=LaneBarcodeParser(lb_path)
         except OSError as e:
             self.log.info(str(e))
             self.lanebarcodes=None
         try:
-            self.lanes=XTenLaneBarcodeParser(ln_path)
+            self.lanes=LaneBarcodeParser(ln_path)
         except OSError as e:
             self.log.info(str(e))
             self.lanes=None
         try:
-            self.undet=XTenUndeterminedParser(demux_path)
+            self.undet=UndeterminedParser(demux_path)
         except OSError as e:
             self.log.info(str(e))
             self.undet=None
@@ -98,7 +100,7 @@ class XTenParser(object):
 
 
 
-class XTenUndeterminedParser(object):
+class UndeterminedParser(object):
     def __init__(self, path ):
         if os.path.exists(path):
             self.path=path
@@ -126,13 +128,13 @@ class XTenUndeterminedParser(object):
                         
                     
 
-class XTenLaneBarcodeParser(object):
+class LaneBarcodeParser(object):
     def __init__(self, path ):
         if os.path.exists(path):
             self.path=path
             self.parse()
         else:
-            raise os.error("XTen laneBarcode.html cannot be found at {0}".format(path))
+            raise os.error(" laneBarcode.html cannot be found at {0}".format(path))
 
     def parse(self):
         self.sample_data=[]
@@ -181,13 +183,13 @@ class XTenLaneBarcodeParser(object):
 
 
 
-class XTenDemultiplexingStatsParser(object):
+class DemultiplexingStatsParser(object):
     def __init__(self, path ):
         if os.path.exists(path):
             self.path=path
             self.parse()
         else:
-            raise os.error("XTen DemultiplexingStats.xml cannot be found at {0}".format(path))
+            raise os.error(" DemultiplexingStats.xml cannot be found at {0}".format(path))
 
     def parse(self):
         data={}
@@ -196,8 +198,8 @@ class XTenDemultiplexingStatsParser(object):
         self.data=xml_to_dict(root)
 
 
-class XTenSampleSheetParser(object):
-    """Parses Xten Samplesheets, with their fake csv format.
+class SampleSheetParser(object):
+    """Parses  Samplesheets, with their fake csv format.
     Should be instancied with the samplesheet path as an argument.
 
     .header : a dict containing the info located under the [Header] section
@@ -210,7 +212,7 @@ class XTenSampleSheetParser(object):
         if os.path.exists(path):
             self.parse(path)
         else:
-            raise os.error("XTen sample sheet cannot be found at {0}".format(path))
+            raise os.error(" sample sheet cannot be found at {0}".format(path))
 
 
 
@@ -309,8 +311,8 @@ class XTenSampleSheetParser(object):
             self.reads=reads
 
 
-class XTenRunInfoParser(object):
-    """Parses Xten RunInfo.xml.
+class RunInfoParser(object):
+    """Parses  RunInfo.xml.
     Should be instancied with the file path as an argument.
 
     .data : a list of hand-picked values :
@@ -329,7 +331,7 @@ class XTenRunInfoParser(object):
         if os.path.exists(path):
             self.parse()
         else:
-            raise os.error("XTen run info cannot be found at {0}".format(path))
+            raise os.error(" run info cannot be found at {0}".format(path))
 
     def parse(self):
         data={}
@@ -351,7 +353,7 @@ class XTenRunInfoParser(object):
 
         
         
-class XTenRunParametersParser(object):
+class RunParametersParser(object):
     """Parses a runParameters.xml file.
        This is a much more general xml parser, it will build a dict from the xml data.
        Attributes might be replaced if children nodes have the same tag as the attributes
@@ -365,7 +367,7 @@ class XTenRunParametersParser(object):
         if os.path.exists(path):
             self.parse()
         else:
-            raise os.error("XTen run parameters cannot be found at {0}".format(path))
+            raise os.error(" run parameters cannot be found at {0}".format(path))
         
     def parse(self):
         data={}

--- a/flowcell_parser/classes.py
+++ b/flowcell_parser/classes.py
@@ -99,32 +99,6 @@ class RunParser(object):
         
 
 
-"""
-class UndeterminedParser(object):
-    def __init__(self, path ):
-        if os.path.exists(path):
-            self.path=path
-            self.result={}
-            self.parse()
-        else:
-            raise os.error("Demultiplexing folder cannot be found at {0}".format(path))
-
-    def parse(self):
-        #will only save the 50 more frequent indexes
-        pattern=re.compile('index_count_L([0-9]).tsv')
-        for file in glob.glob(os.path.join(self.path, 'index_count_L?.tsv')):
-                lane_nb=pattern.search(file).group(1)
-                self.result[lane_nb]=OrderedDict()
-                with open(file, 'r') as f:
-                    total=0
-                    for line in f:
-                        components=line.split('\t')
-                        if len(self.result[lane_nb].keys())< 50:
-                            self.result[lane_nb][components[0]]=int(components[1])
-                        total=total+int(components[1])
-
-                    self.result[lane_nb]['TOTAL']=total
-"""
 
 class DemuxSummaryParser(object):
     def __init__(self, path):

--- a/flowcell_parser/classes.py
+++ b/flowcell_parser/classes.py
@@ -351,6 +351,16 @@ class RunInfoParser(object):
         self.data=data
         self.recipe=make_run_recipe(self.data.get('Reads', {}))
 
+
+    def get_read_configuration(self):
+        """return a list of dicts containig the Read Configuration
+            """
+        readConfig = []
+        try:
+            readConfig = self.data['Reads']
+            return sorted(readConfig, key=lambda r: int(r.get("Number", 0)))
+        except IOError:
+            raise RuntimeError('Reads section not present in RunInfo. Check the FC folder.')
         
         
 class RunParametersParser(object):

--- a/flowcell_parser/classes.py
+++ b/flowcell_parser/classes.py
@@ -272,7 +272,8 @@ class SampleSheetParser(object):
         settings=[]
         csvlines=[]
         data=[]
-        with open(path) as csvfile:
+        flag= 'data' #in case of HiSeq samplesheet only data section is present
+        with open(path, 'rU') as csvfile:
             for line in csvfile.readlines():
                 if '[Header]' in line:
                     flag='HEADER'

--- a/flowcell_parser/classes.py
+++ b/flowcell_parser/classes.py
@@ -156,21 +156,11 @@ class LaneBarcodeParser(object):
 
             keys=[]
             rows=lane_table.find_all('tr')
-            for row in rows[1:]:
-            #I want to skip the first row
+            for row in rows[0:]:
                 if len(row.find_all('th')):
                     #this is the header row
-                    seen_clusters=False
                     for th in row.find_all('th'):
                         key=th.text.replace('<br/>', ' ').replace('&gt;', '>')
-                        if key == '#':
-                            key='Lane'
-                        elif key == 'Clusters':
-                            if not seen_clusters:
-                                key= 'Raw Clusters'
-                                seen_clusters=True
-
-
                         keys.append(key)
                 elif len(row.find_all('td')):
                     values=[]

--- a/tests/test_parse_samplesheet.py
+++ b/tests/test_parse_samplesheet.py
@@ -3,35 +3,35 @@ import flowcell_parser.classes as classes
 
 
 def test_samplesheet():
-    k=classes.XTenSampleSheetParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/SampleSheet.csv')
+    k=classes.SampleSheetParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/SampleSheet.csv')
     assert(k.header is not None)
     assert(k.settings is not None)
     assert(k.reads is not None)
 
 def test_runinfo():
-    k=classes.XTenRunInfoParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/RunInfo.xml')
+    k=classes.RunInfoParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/RunInfo.xml')
     assert(k.data is not None)
 
 def test_runparameters():
-    k=classes.XTenRunParametersParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/runParameters.xml')
+    k=classes.RunParametersParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/runParameters.xml')
     assert(k.data is not None)
     
 
 def test_demuxstats():
-    k=classes.XTenDemultiplexingStatsParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/DemultiplexingStats.xml')
+    k=classes.DemultiplexingStatsParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/DemultiplexingStats.xml')
     assert(k.data is not None)
 
 def test_laneBarcode():
-    k=classes.XTenLaneBarcodeParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/Demultiplexing/Reports/html/H2WY7CCXX/all/all/all/laneBarcode.html')
+    k=classes.LaneBarcodeParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/Demultiplexing/Reports/html/H2WY7CCXX/all/all/all/laneBarcode.html')
     assert(k.flowcell_data is not None)
     assert(k.sample_data is not None)
 
 def test_lane():
-    k=classes.XTenLaneBarcodeParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/Demultiplexing/Reports/html/H2WY7CCXX/all/all/all/laneBarcode.html')
+    k=classes.LaneBarcodeParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX/Demultiplexing/Reports/html/H2WY7CCXX/all/all/all/laneBarcode.html')
     assert(k.sample_data is not None)
 
 def test_parser():
-    k=classes.XTenParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX')
+    k=classes.RunParser('../test_data/150424_ST-E00214_0031_BH2WY7CCXX')
     assert(k.obj is not None)
     assert(k.obj is not {})
     assert(k.obj['run_setup'] is not None)


### PR DESCRIPTION
this is a pretty safe pull request.. with the only problem that breaks everything :-D
@Galithil the re-naming is needed, I am currently working on taca to generalise the concept of Run and having specific inherited classes. Have a parser that is Xten specific in the name is driving me creasy  
